### PR TITLE
feat(ingestion): Add document metadata extraction (#7)

### DIFF
--- a/Docs/metadata-schema.md
+++ b/Docs/metadata-schema.md
@@ -1,0 +1,129 @@
+# Document Metadata Schema
+
+This document describes the metadata schema used by the RAG ingestion pipeline. Metadata is extracted during document loading and stored in the manifest and chunk files.
+
+## Core Metadata Fields
+
+These fields are present for all document types:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Document title (extracted or filename fallback) |
+| `source_path` | string | Absolute path to the source file |
+| `relative_path` | string | Path relative to input directory |
+| `file_extension` | string | File extension without dot (e.g., "pdf", "docx") |
+| `size_bytes` | integer | File size in bytes |
+| `last_modified` | string (ISO 8601) | File system modification timestamp |
+| `content_hash` | string | SHA-256 hash of file contents |
+| `ingestion_timestamp` | string (ISO 8601) | UTC timestamp when document was ingested |
+
+## Optional Core Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `author` | string | Document author |
+| `creation_date` | string (ISO 8601) | Document creation date |
+| `modification_date` | string (ISO 8601) | Document modification date |
+| `subject` | string | Document subject |
+
+## PDF-Specific Metadata
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `page_count` | integer | Number of pages |
+| `is_encrypted` | boolean | Whether PDF is encrypted |
+| `creator` | string | Application that created the PDF |
+| `producer` | string | PDF producer software |
+| `failed_pages` | array[integer] | List of page numbers that failed to extract |
+| `parse_warning` | string | Warning message if partial extraction occurred |
+
+## DOCX-Specific Metadata
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `paragraph_count` | integer | Number of paragraphs |
+| `table_count` | integer | Number of tables |
+| `has_headers` | boolean | Document has headers |
+| `has_footers` | boolean | Document has footers |
+| `keywords` | string | Document keywords |
+| `category` | string | Document category |
+| `comments` | string | Document comments |
+| `last_modified_by` | string | Last person to modify |
+| `revision` | integer | Revision number |
+
+## Markdown/Text-Specific Metadata
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `line_count` | integer | Number of lines |
+| `has_frontmatter` | boolean | YAML front matter present |
+| `headers` | object | Count by level: `{"h1": 2, "h2": 5}` |
+| `code_blocks` | integer | Number of fenced code blocks |
+| `list_items` | integer | Number of list items |
+| `link_count` | integer | Number of markdown links |
+| `tags` | array[string] | Tags from front matter |
+| `description` | string | Description from front matter |
+| `categories` | array[string] | Categories from front matter |
+| `encoding_fallback` | string | Encoding used if UTF-8 failed |
+
+## Normalization Metadata
+
+When text normalization is applied, this nested object is included:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `normalization.original_length` | integer | Character count before normalization |
+| `normalization.normalized_length` | integer | Character count after normalization |
+| `normalization.rules_applied` | array[string] | List of normalization rules applied |
+| `normalization.removed_patterns` | array[string] | Patterns that were removed |
+
+## Example: PDF Document
+
+```json
+{
+  "title": "Technical Report 2024",
+  "author": "John Smith",
+  "creation_date": "2024-01-15T10:30:00",
+  "source_path": "/data/raw/reports/tech-report.pdf",
+  "relative_path": "reports/tech-report.pdf",
+  "file_extension": "pdf",
+  "size_bytes": 1048576,
+  "last_modified": "2024-01-20T14:00:00",
+  "content_hash": "a1b2c3d4...",
+  "ingestion_timestamp": "2024-12-31T10:00:00Z",
+  "page_count": 25,
+  "is_encrypted": false,
+  "creator": "Microsoft Word",
+  "producer": "Adobe PDF Library"
+}
+```
+
+## Example: Markdown Document
+
+```json
+{
+  "title": "Getting Started Guide",
+  "author": "Jane Doe",
+  "creation_date": "2024-06-01",
+  "source_path": "/data/raw/docs/guide.md",
+  "relative_path": "docs/guide.md",
+  "file_extension": "md",
+  "size_bytes": 8192,
+  "last_modified": "2024-06-15T09:00:00",
+  "content_hash": "e5f6g7h8...",
+  "ingestion_timestamp": "2024-12-31T10:00:00Z",
+  "has_frontmatter": true,
+  "tags": ["tutorial", "beginner"],
+  "headers": {"h1": 1, "h2": 4, "h3": 8},
+  "code_blocks": 5,
+  "line_count": 150
+}
+```
+
+## Title Fallback Logic
+
+When `title` is not available in document properties:
+
+1. **PDF**: Uses filename (without extension)
+2. **DOCX**: Uses filename (without extension)
+3. **Markdown**: Uses first H1 header, then filename (without extension)

--- a/ingestion/loader.py
+++ b/ingestion/loader.py
@@ -44,6 +44,40 @@ class DocumentParseError(Exception):
         self.partial_content = partial_content
 
 
+def _parse_pdf_date(date_str: Optional[str]) -> Optional[str]:
+    """Parse PDF date string to ISO format.
+
+    PDF dates are typically in format: D:YYYYMMDDHHmmSS+HH'mm'
+    """
+    if not date_str:
+        return None
+
+    # Remove 'D:' prefix if present
+    if date_str.startswith("D:"):
+        date_str = date_str[2:]
+
+    # Try to parse common PDF date formats
+    try:
+        # Basic format: YYYYMMDDHHMMSS
+        if len(date_str) >= 14:
+            year = date_str[0:4]
+            month = date_str[4:6]
+            day = date_str[6:8]
+            hour = date_str[8:10]
+            minute = date_str[10:12]
+            second = date_str[12:14]
+            return f"{year}-{month}-{day}T{hour}:{minute}:{second}"
+        elif len(date_str) >= 8:
+            year = date_str[0:4]
+            month = date_str[4:6]
+            day = date_str[6:8]
+            return f"{year}-{month}-{day}"
+    except (ValueError, IndexError):
+        pass
+
+    return None
+
+
 def load_pdf(path: Path) -> Tuple[str, Dict[str, Any]]:
     """Load PDF file with error handling for corrupted/invalid files."""
     from PyPDF2 import PdfReader
@@ -57,6 +91,33 @@ def load_pdf(path: Path) -> Tuple[str, Dict[str, Any]]:
         reader = PdfReader(str(path))
         metadata["page_count"] = len(reader.pages)
         metadata["is_encrypted"] = reader.is_encrypted
+
+        # Extract document metadata
+        if reader.metadata:
+            pdf_meta = reader.metadata
+            if pdf_meta.title:
+                metadata["title"] = pdf_meta.title
+            if pdf_meta.author:
+                metadata["author"] = pdf_meta.author
+            if pdf_meta.creator:
+                metadata["creator"] = pdf_meta.creator
+            if pdf_meta.producer:
+                metadata["producer"] = pdf_meta.producer
+            if pdf_meta.subject:
+                metadata["subject"] = pdf_meta.subject
+
+            # Parse dates
+            creation_date = _parse_pdf_date(pdf_meta.creation_date)
+            if creation_date:
+                metadata["creation_date"] = creation_date
+
+            mod_date = _parse_pdf_date(pdf_meta.modification_date)
+            if mod_date:
+                metadata["modification_date"] = mod_date
+
+        # Fallback: use filename as title if not in metadata
+        if "title" not in metadata:
+            metadata["title"] = path.stem
 
         if reader.is_encrypted:
             logger.warning(f"PDF is encrypted: {path}")
@@ -97,6 +158,33 @@ def load_docx(path: Path) -> Tuple[str, Dict[str, Any]]:
 
     try:
         doc = docx.Document(str(path))
+
+        # Extract core properties (document metadata)
+        core_props = doc.core_properties
+        if core_props.title:
+            metadata["title"] = core_props.title
+        if core_props.author:
+            metadata["author"] = core_props.author
+        if core_props.subject:
+            metadata["subject"] = core_props.subject
+        if core_props.keywords:
+            metadata["keywords"] = core_props.keywords
+        if core_props.category:
+            metadata["category"] = core_props.category
+        if core_props.comments:
+            metadata["comments"] = core_props.comments
+        if core_props.created:
+            metadata["creation_date"] = core_props.created.isoformat()
+        if core_props.modified:
+            metadata["modification_date"] = core_props.modified.isoformat()
+        if core_props.last_modified_by:
+            metadata["last_modified_by"] = core_props.last_modified_by
+        if core_props.revision is not None:
+            metadata["revision"] = core_props.revision
+
+        # Fallback: use filename as title if not in metadata
+        if "title" not in metadata:
+            metadata["title"] = path.stem
 
         # Extract paragraphs
         paragraphs = [para.text.strip() for para in doc.paragraphs if para.text.strip()]
@@ -145,6 +233,51 @@ def load_docx(path: Path) -> Tuple[str, Dict[str, Any]]:
     return "\n\n".join(content_parts), metadata
 
 
+def _parse_yaml_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
+    """Parse YAML front matter from markdown content.
+
+    Returns:
+        Tuple of (frontmatter_dict, content_without_frontmatter)
+    """
+    if not content.startswith("---"):
+        return {}, content
+
+    # Find the closing ---
+    end_marker = content.find("\n---", 3)
+    if end_marker == -1:
+        return {}, content
+
+    frontmatter_str = content[4:end_marker].strip()
+    remaining_content = content[end_marker + 4:].lstrip("\n")
+
+    # Parse YAML manually (simple key: value pairs)
+    frontmatter = {}
+    for line in frontmatter_str.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+
+            # Remove quotes if present
+            if (value.startswith('"') and value.endswith('"')) or \
+               (value.startswith("'") and value.endswith("'")):
+                value = value[1:-1]
+
+            # Handle arrays (simple format: [item1, item2])
+            if value.startswith("[") and value.endswith("]"):
+                items = value[1:-1].split(",")
+                value = [item.strip().strip("\"'") for item in items if item.strip()]
+
+            if value:
+                frontmatter[key] = value
+
+    return frontmatter, remaining_content
+
+
 def load_markdown(path: Path) -> Tuple[str, Dict[str, Any]]:
     """Load Markdown/text file with structure-aware parsing and error handling."""
     metadata = {}
@@ -168,11 +301,30 @@ def load_markdown(path: Path) -> Tuple[str, Dict[str, Any]]:
         logger.error(f"Failed to read file: {path} - {e}")
         raise DocumentParseError(f"File read error: {e}", path)
 
+    # Parse front matter if present
+    frontmatter, _ = _parse_yaml_frontmatter(content)
+    if frontmatter:
+        metadata["has_frontmatter"] = True
+        # Extract common frontmatter fields
+        if "title" in frontmatter:
+            metadata["title"] = frontmatter["title"]
+        if "author" in frontmatter:
+            metadata["author"] = frontmatter["author"]
+        if "date" in frontmatter:
+            metadata["creation_date"] = frontmatter["date"]
+        if "tags" in frontmatter:
+            metadata["tags"] = frontmatter["tags"]
+        if "description" in frontmatter:
+            metadata["description"] = frontmatter["description"]
+        if "categories" in frontmatter:
+            metadata["categories"] = frontmatter["categories"]
+
     # Extract markdown structure metadata
     lines = content.split("\n")
 
-    # Count headers by level (require space after # for valid markdown headers)
+    # Count headers by level and extract first H1 for title fallback
     headers = {"h1": 0, "h2": 0, "h3": 0, "h4": 0, "h5": 0, "h6": 0}
+    first_h1 = None
     for line in lines:
         stripped = line.strip()
         if stripped.startswith("###### ") or stripped == "######":
@@ -185,11 +337,22 @@ def load_markdown(path: Path) -> Tuple[str, Dict[str, Any]]:
             headers["h3"] += 1
         elif stripped.startswith("## ") or stripped == "##":
             headers["h2"] += 1
-        elif stripped.startswith("# ") or stripped == "#":
+        elif stripped.startswith("# "):
+            headers["h1"] += 1
+            if first_h1 is None:
+                first_h1 = stripped[2:].strip()
+        elif stripped == "#":
             headers["h1"] += 1
 
     if any(headers.values()):
         metadata["headers"] = {k: v for k, v in headers.items() if v > 0}
+
+    # Fallback: use first H1 as title, then filename
+    if "title" not in metadata:
+        if first_h1:
+            metadata["title"] = first_h1
+        else:
+            metadata["title"] = path.stem
 
     # Detect code blocks
     code_block_count = content.count("```") // 2
@@ -205,12 +368,6 @@ def load_markdown(path: Path) -> Tuple[str, Dict[str, Any]]:
     links = re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
     if links:
         metadata["link_count"] = len(links)
-
-    # Extract front matter if present (YAML)
-    if content.startswith("---"):
-        end_marker = content.find("---", 3)
-        if end_marker != -1:
-            metadata["has_frontmatter"] = True
 
     metadata["line_count"] = len(lines)
 
@@ -279,6 +436,7 @@ class DocumentLoader:
         metadata.update(extra_metadata or {})
         content_hash = hash_file(path)
         metadata["content_hash"] = content_hash
+        metadata["ingestion_timestamp"] = datetime.utcnow().isoformat() + "Z"
 
         # Add normalization metadata if normalization was applied
         if normalization_result is not None:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,7 @@
 """Unit tests for document loaders (PDF, DOCX, Markdown)."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -8,6 +9,8 @@ import pytest
 
 from ingestion.loader import (
     DocumentParseError,
+    _parse_pdf_date,
+    _parse_yaml_frontmatter,
     load_docx,
     load_markdown,
     load_pdf,
@@ -455,3 +458,278 @@ class TestErrorHandling:
                 load_docx(docx_path)
 
             assert "Corrupted DOCX" in str(exc_info.value)
+
+
+class TestPDFMetadataExtraction:
+    """Tests for PDF metadata extraction."""
+
+    def test_parse_pdf_date_full_format(self):
+        """Test parsing full PDF date format."""
+        result = _parse_pdf_date("D:20240115103045")
+        assert result == "2024-01-15T10:30:45"
+
+    def test_parse_pdf_date_short_format(self):
+        """Test parsing short PDF date format."""
+        result = _parse_pdf_date("D:20240115")
+        assert result == "2024-01-15"
+
+    def test_parse_pdf_date_without_prefix(self):
+        """Test parsing date without D: prefix."""
+        result = _parse_pdf_date("20240115103045")
+        assert result == "2024-01-15T10:30:45"
+
+    def test_parse_pdf_date_none(self):
+        """Test parsing None date."""
+        result = _parse_pdf_date(None)
+        assert result is None
+
+    def test_parse_pdf_date_empty(self):
+        """Test parsing empty date."""
+        result = _parse_pdf_date("")
+        assert result is None
+
+    def test_load_pdf_extracts_metadata(self, tmp_path: Path):
+        """Test PDF metadata extraction from document properties."""
+        with patch("PyPDF2.PdfReader") as mock_reader:
+            mock_page = MagicMock()
+            mock_page.extract_text.return_value = "Content"
+
+            mock_metadata = MagicMock()
+            mock_metadata.title = "Test Document"
+            mock_metadata.author = "John Doe"
+            mock_metadata.creator = "Microsoft Word"
+            mock_metadata.producer = "Adobe PDF"
+            mock_metadata.subject = "Testing"
+            mock_metadata.creation_date = "D:20240115103000"
+            mock_metadata.modification_date = "D:20240120140000"
+
+            mock_reader.return_value.pages = [mock_page]
+            mock_reader.return_value.is_encrypted = False
+            mock_reader.return_value.metadata = mock_metadata
+
+            pdf_path = tmp_path / "test.pdf"
+            pdf_path.touch()
+
+            text, metadata = load_pdf(pdf_path)
+
+            assert metadata["title"] == "Test Document"
+            assert metadata["author"] == "John Doe"
+            assert metadata["creator"] == "Microsoft Word"
+            assert metadata["producer"] == "Adobe PDF"
+            assert metadata["subject"] == "Testing"
+            assert metadata["creation_date"] == "2024-01-15T10:30:00"
+            assert metadata["modification_date"] == "2024-01-20T14:00:00"
+
+    def test_load_pdf_title_fallback_to_filename(self, tmp_path: Path):
+        """Test PDF uses filename as title when metadata is empty."""
+        with patch("PyPDF2.PdfReader") as mock_reader:
+            mock_page = MagicMock()
+            mock_page.extract_text.return_value = "Content"
+
+            mock_metadata = MagicMock()
+            mock_metadata.title = None
+            mock_metadata.author = None
+            mock_metadata.creator = None
+            mock_metadata.producer = None
+            mock_metadata.subject = None
+            mock_metadata.creation_date = None
+            mock_metadata.modification_date = None
+
+            mock_reader.return_value.pages = [mock_page]
+            mock_reader.return_value.is_encrypted = False
+            mock_reader.return_value.metadata = mock_metadata
+
+            pdf_path = tmp_path / "my_document.pdf"
+            pdf_path.touch()
+
+            text, metadata = load_pdf(pdf_path)
+
+            assert metadata["title"] == "my_document"
+
+
+class TestDOCXMetadataExtraction:
+    """Tests for DOCX metadata extraction."""
+
+    def test_load_docx_extracts_core_properties(self, tmp_path: Path):
+        """Test DOCX metadata extraction from core properties."""
+        with patch("docx.Document") as mock_doc:
+            mock_doc.return_value.paragraphs = []
+            mock_doc.return_value.tables = []
+            mock_doc.return_value.sections = []
+
+            mock_core_props = MagicMock()
+            mock_core_props.title = "Test Document"
+            mock_core_props.author = "Jane Smith"
+            mock_core_props.subject = "Testing"
+            mock_core_props.keywords = "test, unit, python"
+            mock_core_props.category = "Documentation"
+            mock_core_props.comments = "Test file"
+            mock_core_props.created = datetime(2024, 1, 15, 10, 30, 0)
+            mock_core_props.modified = datetime(2024, 1, 20, 14, 0, 0)
+            mock_core_props.last_modified_by = "John Doe"
+            mock_core_props.revision = 5
+
+            mock_doc.return_value.core_properties = mock_core_props
+
+            docx_path = tmp_path / "test.docx"
+            docx_path.touch()
+
+            text, metadata = load_docx(docx_path)
+
+            assert metadata["title"] == "Test Document"
+            assert metadata["author"] == "Jane Smith"
+            assert metadata["subject"] == "Testing"
+            assert metadata["keywords"] == "test, unit, python"
+            assert metadata["category"] == "Documentation"
+            assert metadata["comments"] == "Test file"
+            assert "2024-01-15" in metadata["creation_date"]
+            assert "2024-01-20" in metadata["modification_date"]
+            assert metadata["last_modified_by"] == "John Doe"
+            assert metadata["revision"] == 5
+
+    def test_load_docx_title_fallback_to_filename(self, tmp_path: Path):
+        """Test DOCX uses filename as title when core properties empty."""
+        with patch("docx.Document") as mock_doc:
+            mock_doc.return_value.paragraphs = []
+            mock_doc.return_value.tables = []
+            mock_doc.return_value.sections = []
+
+            mock_core_props = MagicMock()
+            mock_core_props.title = None
+            mock_core_props.author = None
+            mock_core_props.subject = None
+            mock_core_props.keywords = None
+            mock_core_props.category = None
+            mock_core_props.comments = None
+            mock_core_props.created = None
+            mock_core_props.modified = None
+            mock_core_props.last_modified_by = None
+            mock_core_props.revision = None
+
+            mock_doc.return_value.core_properties = mock_core_props
+
+            docx_path = tmp_path / "my_report.docx"
+            docx_path.touch()
+
+            text, metadata = load_docx(docx_path)
+
+            assert metadata["title"] == "my_report"
+
+
+class TestMarkdownMetadataExtraction:
+    """Tests for Markdown metadata extraction."""
+
+    def test_parse_yaml_frontmatter_basic(self):
+        """Test parsing basic YAML front matter."""
+        content = """---
+title: My Document
+author: John Doe
+date: 2024-01-15
+---
+
+# Content"""
+        frontmatter, remaining = _parse_yaml_frontmatter(content)
+
+        assert frontmatter["title"] == "My Document"
+        assert frontmatter["author"] == "John Doe"
+        assert frontmatter["date"] == "2024-01-15"
+        assert remaining.strip().startswith("# Content")
+
+    def test_parse_yaml_frontmatter_with_quotes(self):
+        """Test parsing front matter with quoted values."""
+        content = """---
+title: "My Document: A Study"
+author: 'Jane Doe'
+---
+
+Content"""
+        frontmatter, _ = _parse_yaml_frontmatter(content)
+
+        assert frontmatter["title"] == "My Document: A Study"
+        assert frontmatter["author"] == "Jane Doe"
+
+    def test_parse_yaml_frontmatter_with_array(self):
+        """Test parsing front matter with array values."""
+        content = """---
+tags: [python, testing, unit]
+---
+
+Content"""
+        frontmatter, _ = _parse_yaml_frontmatter(content)
+
+        assert frontmatter["tags"] == ["python", "testing", "unit"]
+
+    def test_parse_yaml_frontmatter_no_frontmatter(self):
+        """Test parsing content without front matter."""
+        content = "# Just a heading\n\nSome content."
+        frontmatter, remaining = _parse_yaml_frontmatter(content)
+
+        assert frontmatter == {}
+        assert remaining == content
+
+    def test_load_markdown_extracts_frontmatter_metadata(self, tmp_path: Path):
+        """Test markdown extracts metadata from front matter."""
+        content = """---
+title: Getting Started
+author: Alice
+date: 2024-06-01
+tags: [tutorial, beginner]
+description: A beginner's guide
+---
+
+# Introduction
+
+Welcome to the guide."""
+        md_path = tmp_path / "guide.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        text, metadata = load_markdown(md_path)
+
+        assert metadata["title"] == "Getting Started"
+        assert metadata["author"] == "Alice"
+        assert metadata["creation_date"] == "2024-06-01"
+        assert metadata["tags"] == ["tutorial", "beginner"]
+        assert metadata["description"] == "A beginner's guide"
+        assert metadata["has_frontmatter"] is True
+
+    def test_load_markdown_title_fallback_to_h1(self, tmp_path: Path):
+        """Test markdown uses first H1 as title when no front matter."""
+        content = """# My Amazing Article
+
+Some introductory text.
+
+## Section 1
+
+More content."""
+        md_path = tmp_path / "article.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        text, metadata = load_markdown(md_path)
+
+        assert metadata["title"] == "My Amazing Article"
+
+    def test_load_markdown_title_fallback_to_filename(self, tmp_path: Path):
+        """Test markdown uses filename as title when no H1 or front matter."""
+        content = """Just some plain text without any headers."""
+        md_path = tmp_path / "notes.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        text, metadata = load_markdown(md_path)
+
+        assert metadata["title"] == "notes"
+
+    def test_load_markdown_frontmatter_overrides_h1(self, tmp_path: Path):
+        """Test front matter title takes precedence over H1."""
+        content = """---
+title: Official Title
+---
+
+# Different H1 Title
+
+Content here."""
+        md_path = tmp_path / "test.md"
+        md_path.write_text(content, encoding="utf-8")
+
+        text, metadata = load_markdown(md_path)
+
+        assert metadata["title"] == "Official Title"


### PR DESCRIPTION
## Summary
- Extract title, author, creation_date from PDF document metadata
- Extract core properties from DOCX files (title, author, dates, keywords, category)
- Parse YAML front matter from Markdown files for metadata extraction
- Implement title fallback logic: metadata → first H1 header → filename
- Add `ingestion_timestamp` field to all processed documents
- Create comprehensive metadata schema documentation

## Changes
- `ingestion/loader.py`: Enhanced `load_pdf()`, `load_docx()`, `load_markdown()` with metadata extraction
- `Docs/metadata-schema.md`: New documentation for all metadata fields
- `tests/test_loader.py`: Added 17 new unit tests for metadata extraction

## Test plan
- [x] All 41 loader tests pass
- [x] PDF metadata extraction verified
- [x] DOCX core properties extraction verified
- [x] Markdown front matter parsing verified
- [x] Title fallback logic verified for all formats

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)