### PR TITLE
feat: Add Excel file support (.xlsx, .xls)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 ﻿PyPDF2>=3.0.0
 python-docx>=1.1.0
+openpyxl>=3.1.0
+xlrd>=2.0.0
 chromadb>=0.4.22
 sentence-transformers>=2.2.2
 PyYAML>=6.0


### PR DESCRIPTION
## Summary
- Add support for ingesting Excel files (.xlsx and .xls) into the RAG pipeline
- Implement `load_excel()` for .xlsx files using openpyxl
- Implement `load_excel_xls()` for legacy .xls files using xlrd
- Extract metadata: title, author, dates, sheet_names, sheet_count, row_count
- Insert `[SHEET:name]` markers between sheets (similar to `[PAGE:N]` for PDFs)
- Handle password-protected and corrupted files gracefully

## Test plan
- [x] Verify Excel handlers load successfully
- [x] Run existing test suite (227 passed)
- [ ] Test with real .xlsx file
- [ ] Test with real .xls file
- [ ] Test with multi-sheet workbook
- [ ] Test with password-protected file

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)