### PR TITLE
feat: Add multi-provider LLM support (OpenAI, Anthropic, Ollama)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
 # LLM API Configuration for RAG Chat
 # Copy this file to .env and fill in your actual values
 
+# =============================================================================
+# LLM Provider Selection
+# =============================================================================
+# Choose which LLM provider to use. Options: custom, openai, anthropic, ollama
+# Default: custom (backwards compatible with existing HMAC-authenticated API)
+LLM_PROVIDER=custom
+
+# =============================================================================
+# Custom HMAC-Authenticated API (default provider)
+# =============================================================================
 # Your API key for authentication
 API_KEY=your_api_key_here
 
@@ -9,3 +19,35 @@ API_SECRET=your_api_secret_here
 
 # Base URL for the LLM API endpoint (without trailing slash)
 BASE_URL=https://your-llm-api-endpoint.com
+
+# =============================================================================
+# OpenAI Configuration (when LLM_PROVIDER=openai)
+# =============================================================================
+# Your OpenAI API key (starts with sk-)
+OPENAI_API_KEY=sk-your-api-key-here
+
+# Model to use (default: gpt-4o)
+# Options: gpt-4o, gpt-4-turbo, gpt-4, gpt-3.5-turbo, etc.
+OPENAI_MODEL=gpt-4o
+
+# =============================================================================
+# Anthropic Configuration (when LLM_PROVIDER=anthropic)
+# =============================================================================
+# Your Anthropic API key (starts with sk-ant-)
+ANTHROPIC_API_KEY=sk-ant-your-api-key-here
+
+# Model to use (default: claude-3-5-sonnet-20241022)
+# Options: claude-3-5-sonnet-20241022, claude-3-opus-20240229, claude-3-haiku-20240307
+ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
+
+# =============================================================================
+# Ollama Configuration (when LLM_PROVIDER=ollama)
+# =============================================================================
+# For local/offline use with Ollama (https://ollama.ai/)
+
+# Base URL for Ollama server (default: http://localhost:11434)
+OLLAMA_BASE_URL=http://localhost:11434
+
+# Model to use (default: llama3.2)
+# Run 'ollama list' to see available models
+OLLAMA_MODEL=llama3.2

--- a/generation/__init__.py
+++ b/generation/__init__.py
@@ -1,6 +1,43 @@
-"""Generation module for RAG response generation."""
+"""Generation module for RAG response generation.
 
-from generation.api_client import LLMClient, LLMConfig
-from generation.rag_chain import RAGChain
+This module provides LLM clients and the RAG chain for document-based Q&A.
 
-__all__ = ["LLMClient", "LLMConfig", "RAGChain"]
+Providers:
+    - custom: HMAC-authenticated custom API (default, backwards compatible)
+    - openai: OpenAI API (GPT-4, GPT-4o, etc.)
+    - anthropic: Anthropic API (Claude)
+    - ollama: Local Ollama server
+
+Usage:
+    # Use factory to get client based on LLM_PROVIDER env var
+    from generation import create_llm_client, RAGChain
+    client = create_llm_client()
+    rag = RAGChain(client)
+
+    # Or explicitly specify provider
+    client = create_llm_client("openai")
+"""
+
+from .api_client import LLMClient, LLMClientError, LLMConfig, LLMResponse, Message
+from .base import BaseLLMClient
+from .factory import ProviderError, create_llm_client, get_available_providers
+from .rag_chain import RAGChain, RAGConfig, RAGResponse
+
+__all__ = [
+    # Core types
+    "LLMClient",
+    "LLMConfig",
+    "LLMResponse",
+    "LLMClientError",
+    "Message",
+    # Protocol
+    "BaseLLMClient",
+    # Factory
+    "create_llm_client",
+    "get_available_providers",
+    "ProviderError",
+    # RAG
+    "RAGChain",
+    "RAGConfig",
+    "RAGResponse",
+]

--- a/generation/base.py
+++ b/generation/base.py
@@ -1,0 +1,59 @@
+"""Base protocol/interface for LLM clients.
+
+This module defines the BaseLLMClient protocol that all LLM providers must implement.
+Using Python's Protocol for structural subtyping allows existing classes to be
+compatible without explicit inheritance.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+from .api_client import LLMResponse, Message
+
+
+@runtime_checkable
+class BaseLLMClient(Protocol):
+    """Protocol defining the interface for LLM clients.
+
+    All LLM provider implementations must support these methods.
+    Uses structural subtyping - any class with matching methods is compatible.
+    """
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Generate a response from a prompt.
+
+        Args:
+            prompt: The user prompt/question.
+            system_prompt: Optional system instructions.
+            max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature (0.0-1.0).
+
+        Returns:
+            Generated text content.
+        """
+        ...
+
+    def chat(
+        self,
+        messages: list[Message],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> LLMResponse:
+        """Send a chat request with multiple messages.
+
+        Args:
+            messages: List of chat messages with role and content.
+            max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature (0.0-1.0).
+
+        Returns:
+            LLM response with content and metadata.
+        """
+        ...

--- a/generation/factory.py
+++ b/generation/factory.py
@@ -1,0 +1,118 @@
+"""Factory function for creating LLM clients.
+
+This module provides a factory function that instantiates the correct LLM client
+based on configuration. The default provider is 'custom' which uses the existing
+HMAC-authenticated client for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .api_client import LLMClient, LLMConfig
+from .base import BaseLLMClient
+
+
+# Supported provider names
+PROVIDERS = frozenset({"custom", "openai", "anthropic", "ollama"})
+
+# Default provider (backwards compatible with existing behavior)
+DEFAULT_PROVIDER = "custom"
+
+
+class ProviderError(Exception):
+    """Error related to LLM provider configuration."""
+
+    pass
+
+
+def create_llm_client(provider: Optional[str] = None) -> BaseLLMClient:
+    """Create an LLM client based on the specified provider.
+
+    This factory function instantiates the appropriate LLM client based on
+    the provider name. If no provider is specified, it reads from the
+    LLM_PROVIDER environment variable, defaulting to 'custom' for
+    backwards compatibility.
+
+    Args:
+        provider: Provider name. One of: custom, openai, anthropic, ollama.
+                  If None, reads from LLM_PROVIDER env var (default: custom).
+
+    Returns:
+        An LLM client implementing the BaseLLMClient protocol.
+
+    Raises:
+        ProviderError: If the provider is unknown or configuration is invalid.
+
+    Examples:
+        # Use default provider (from env or 'custom')
+        client = create_llm_client()
+
+        # Explicitly specify provider
+        client = create_llm_client("openai")
+
+        # Use with RAGChain
+        from generation.factory import create_llm_client
+        from generation.rag_chain import RAGChain
+        rag = RAGChain(create_llm_client())
+    """
+    # Get provider from argument, env var, or default
+    provider = provider or os.getenv("LLM_PROVIDER", DEFAULT_PROVIDER)
+    provider = provider.lower().strip()
+
+    if provider not in PROVIDERS:
+        raise ProviderError(
+            f"Unknown LLM provider: '{provider}'. "
+            f"Supported providers: {', '.join(sorted(PROVIDERS))}"
+        )
+
+    try:
+        if provider == "custom":
+            return _create_custom_client()
+        elif provider == "openai":
+            return _create_openai_client()
+        elif provider == "anthropic":
+            return _create_anthropic_client()
+        elif provider == "ollama":
+            return _create_ollama_client()
+        else:
+            raise ProviderError(f"Provider '{provider}' is not implemented")
+    except ValueError as e:
+        raise ProviderError(f"Failed to configure {provider} provider: {e}") from e
+
+
+def _create_custom_client() -> LLMClient:
+    """Create the custom HMAC-authenticated client."""
+    config = LLMConfig.from_env()
+    return LLMClient(config)
+
+
+def _create_openai_client() -> BaseLLMClient:
+    """Create an OpenAI client."""
+    from .providers.openai_client import OpenAIClient
+
+    return OpenAIClient()
+
+
+def _create_anthropic_client() -> BaseLLMClient:
+    """Create an Anthropic client."""
+    from .providers.anthropic_client import AnthropicClient
+
+    return AnthropicClient()
+
+
+def _create_ollama_client() -> BaseLLMClient:
+    """Create an Ollama client."""
+    from .providers.ollama_client import OllamaClient
+
+    return OllamaClient()
+
+
+def get_available_providers() -> list[str]:
+    """Get list of available provider names.
+
+    Returns:
+        Sorted list of provider names.
+    """
+    return sorted(PROVIDERS)

--- a/generation/providers/__init__.py
+++ b/generation/providers/__init__.py
@@ -1,0 +1,15 @@
+"""LLM provider implementations.
+
+This package contains client implementations for various LLM providers:
+- OpenAI (GPT-4, GPT-4o, etc.)
+- Anthropic (Claude)
+- Ollama (local/offline models)
+
+All providers implement the BaseLLMClient protocol defined in generation.base.
+"""
+
+from .anthropic_client import AnthropicClient
+from .ollama_client import OllamaClient
+from .openai_client import OpenAIClient
+
+__all__ = ["OpenAIClient", "AnthropicClient", "OllamaClient"]

--- a/generation/providers/anthropic_client.py
+++ b/generation/providers/anthropic_client.py
@@ -1,0 +1,152 @@
+"""Anthropic (Claude) LLM client implementation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from ..api_client import LLMClientError, LLMResponse, Message
+
+
+@dataclass
+class AnthropicConfig:
+    """Configuration for Anthropic API client."""
+
+    api_key: str
+    model: str = "claude-3-5-sonnet-20241022"
+    max_tokens: int = 1000
+    temperature: float = 0.7
+    timeout: int = 60
+
+    @classmethod
+    def from_env(cls) -> "AnthropicConfig":
+        """Create config from environment variables."""
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY environment variable is required")
+
+        return cls(
+            api_key=api_key,
+            model=os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022"),
+        )
+
+
+class AnthropicClient:
+    """Anthropic API client implementing BaseLLMClient protocol."""
+
+    def __init__(self, config: Optional[AnthropicConfig] = None):
+        """Initialize the Anthropic client.
+
+        Args:
+            config: Anthropic configuration. If None, loads from environment.
+        """
+        self.config = config or AnthropicConfig.from_env()
+        self._client = None
+
+    def _get_client(self):
+        """Lazy initialization of Anthropic client."""
+        if self._client is None:
+            try:
+                from anthropic import Anthropic
+            except ImportError:
+                raise LLMClientError(
+                    "Anthropic package not installed. "
+                    "Install with: pip install anthropic"
+                )
+            self._client = Anthropic(
+                api_key=self.config.api_key,
+                timeout=self.config.timeout,
+            )
+        return self._client
+
+    def chat(
+        self,
+        messages: list[Message],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> LLMResponse:
+        """Send a chat request to Anthropic API.
+
+        Args:
+            messages: List of chat messages.
+            max_tokens: Override default max tokens.
+            temperature: Override default temperature.
+
+        Returns:
+            LLM response.
+
+        Raises:
+            LLMClientError: If the API request fails.
+        """
+        client = self._get_client()
+
+        # Anthropic expects system prompt separately
+        system_prompt = None
+        anthropic_messages = []
+
+        for m in messages:
+            if m.role == "system":
+                system_prompt = m.content
+            else:
+                anthropic_messages.append({"role": m.role, "content": m.content})
+
+        try:
+            kwargs = {
+                "model": self.config.model,
+                "messages": anthropic_messages,
+                "max_tokens": max_tokens or self.config.max_tokens,
+                "temperature": temperature if temperature is not None else self.config.temperature,
+            }
+            if system_prompt:
+                kwargs["system"] = system_prompt
+
+            response = client.messages.create(**kwargs)
+        except Exception as e:
+            raise LLMClientError(f"Anthropic API request failed: {e}") from e
+
+        # Extract content from response
+        content = ""
+        if response.content:
+            content = response.content[0].text
+
+        usage = None
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.input_tokens,
+                "completion_tokens": response.usage.output_tokens,
+                "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+            }
+
+        return LLMResponse(
+            content=content,
+            model=response.model,
+            usage=usage,
+            raw_response=response.model_dump() if hasattr(response, "model_dump") else None,
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Simple generation interface.
+
+        Args:
+            prompt: User prompt.
+            system_prompt: Optional system prompt.
+            max_tokens: Override default max tokens.
+            temperature: Override default temperature.
+
+        Returns:
+            Generated text content.
+        """
+        messages = []
+        if system_prompt:
+            messages.append(Message(role="system", content=system_prompt))
+        messages.append(Message(role="user", content=prompt))
+
+        response = self.chat(messages, max_tokens=max_tokens, temperature=temperature)
+        return response.content

--- a/generation/providers/ollama_client.py
+++ b/generation/providers/ollama_client.py
@@ -1,0 +1,191 @@
+"""Ollama LLM client implementation for local/offline use."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+
+from ..api_client import LLMClientError, LLMResponse, Message
+
+
+@dataclass
+class OllamaConfig:
+    """Configuration for Ollama API client."""
+
+    base_url: str = "http://localhost:11434"
+    model: str = "llama3.2"
+    max_tokens: int = 1000
+    temperature: float = 0.7
+    timeout: int = 120  # Longer timeout for local models
+
+    @classmethod
+    def from_env(cls) -> "OllamaConfig":
+        """Create config from environment variables."""
+        return cls(
+            base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+            model=os.getenv("OLLAMA_MODEL", "llama3.2"),
+        )
+
+
+class OllamaClient:
+    """Ollama API client implementing BaseLLMClient protocol.
+
+    Ollama is a local LLM server for running models offline.
+    See: https://ollama.ai/
+    """
+
+    def __init__(self, config: Optional[OllamaConfig] = None):
+        """Initialize the Ollama client.
+
+        Args:
+            config: Ollama configuration. If None, loads from environment.
+        """
+        self.config = config or OllamaConfig.from_env()
+
+    def chat(
+        self,
+        messages: list[Message],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> LLMResponse:
+        """Send a chat request to Ollama API.
+
+        Args:
+            messages: List of chat messages.
+            max_tokens: Override default max tokens (maps to num_predict).
+            temperature: Override default temperature.
+
+        Returns:
+            LLM response.
+
+        Raises:
+            LLMClientError: If the API request fails.
+        """
+        url = f"{self.config.base_url}/api/chat"
+
+        ollama_messages = [
+            {"role": m.role, "content": m.content} for m in messages
+        ]
+
+        request_body = {
+            "model": self.config.model,
+            "messages": ollama_messages,
+            "stream": False,
+            "options": {
+                "num_predict": max_tokens or self.config.max_tokens,
+                "temperature": temperature if temperature is not None else self.config.temperature,
+            },
+        }
+
+        try:
+            response = requests.post(
+                url,
+                json=request_body,
+                timeout=self.config.timeout,
+            )
+        except requests.ConnectionError as e:
+            raise LLMClientError(
+                f"Could not connect to Ollama at {self.config.base_url}. "
+                "Make sure Ollama is running: ollama serve"
+            ) from e
+        except requests.RequestException as e:
+            raise LLMClientError(f"Ollama API request failed: {e}") from e
+
+        if response.status_code != 200:
+            raise LLMClientError(
+                f"Ollama API returned status code {response.status_code}: {response.text}"
+            )
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            raise LLMClientError(f"Invalid JSON response from Ollama: {e}") from e
+
+        try:
+            content = data["message"]["content"]
+        except KeyError as e:
+            raise LLMClientError(f"Unexpected Ollama response format: {e}") from e
+
+        # Extract usage info if available
+        usage = None
+        if "eval_count" in data or "prompt_eval_count" in data:
+            usage = {
+                "prompt_tokens": data.get("prompt_eval_count", 0),
+                "completion_tokens": data.get("eval_count", 0),
+                "total_tokens": data.get("prompt_eval_count", 0) + data.get("eval_count", 0),
+            }
+
+        return LLMResponse(
+            content=content,
+            model=data.get("model"),
+            usage=usage,
+            raw_response=data,
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Simple generation interface.
+
+        Args:
+            prompt: User prompt.
+            system_prompt: Optional system prompt.
+            max_tokens: Override default max tokens.
+            temperature: Override default temperature.
+
+        Returns:
+            Generated text content.
+        """
+        messages = []
+        if system_prompt:
+            messages.append(Message(role="system", content=system_prompt))
+        messages.append(Message(role="user", content=prompt))
+
+        response = self.chat(messages, max_tokens=max_tokens, temperature=temperature)
+        return response.content
+
+    def is_available(self) -> bool:
+        """Check if Ollama server is running and accessible.
+
+        Returns:
+            True if Ollama is available, False otherwise.
+        """
+        try:
+            response = requests.get(
+                f"{self.config.base_url}/api/tags",
+                timeout=5,
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def list_models(self) -> list[str]:
+        """List available models on the Ollama server.
+
+        Returns:
+            List of model names.
+
+        Raises:
+            LLMClientError: If the request fails.
+        """
+        try:
+            response = requests.get(
+                f"{self.config.base_url}/api/tags",
+                timeout=10,
+            )
+        except requests.RequestException as e:
+            raise LLMClientError(f"Failed to list Ollama models: {e}") from e
+
+        if response.status_code != 200:
+            raise LLMClientError(f"Failed to list models: {response.text}")
+
+        data = response.json()
+        return [model["name"] for model in data.get("models", [])]

--- a/generation/providers/openai_client.py
+++ b/generation/providers/openai_client.py
@@ -1,0 +1,139 @@
+"""OpenAI LLM client implementation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from ..api_client import LLMClientError, LLMResponse, Message
+
+
+@dataclass
+class OpenAIConfig:
+    """Configuration for OpenAI API client."""
+
+    api_key: str
+    model: str = "gpt-4o"
+    max_tokens: int = 1000
+    temperature: float = 0.7
+    timeout: int = 60
+
+    @classmethod
+    def from_env(cls) -> "OpenAIConfig":
+        """Create config from environment variables."""
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY environment variable is required")
+
+        return cls(
+            api_key=api_key,
+            model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+        )
+
+
+class OpenAIClient:
+    """OpenAI API client implementing BaseLLMClient protocol."""
+
+    def __init__(self, config: Optional[OpenAIConfig] = None):
+        """Initialize the OpenAI client.
+
+        Args:
+            config: OpenAI configuration. If None, loads from environment.
+        """
+        self.config = config or OpenAIConfig.from_env()
+        self._client = None
+
+    def _get_client(self):
+        """Lazy initialization of OpenAI client."""
+        if self._client is None:
+            try:
+                from openai import OpenAI
+            except ImportError:
+                raise LLMClientError(
+                    "OpenAI package not installed. "
+                    "Install with: pip install openai"
+                )
+            self._client = OpenAI(
+                api_key=self.config.api_key,
+                timeout=self.config.timeout,
+            )
+        return self._client
+
+    def chat(
+        self,
+        messages: list[Message],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> LLMResponse:
+        """Send a chat request to OpenAI API.
+
+        Args:
+            messages: List of chat messages.
+            max_tokens: Override default max tokens.
+            temperature: Override default temperature.
+
+        Returns:
+            LLM response.
+
+        Raises:
+            LLMClientError: If the API request fails.
+        """
+        client = self._get_client()
+
+        openai_messages = [
+            {"role": m.role, "content": m.content} for m in messages
+        ]
+
+        try:
+            response = client.chat.completions.create(
+                model=self.config.model,
+                messages=openai_messages,
+                max_tokens=max_tokens or self.config.max_tokens,
+                temperature=temperature if temperature is not None else self.config.temperature,
+            )
+        except Exception as e:
+            raise LLMClientError(f"OpenAI API request failed: {e}") from e
+
+        content = response.choices[0].message.content or ""
+
+        usage = None
+        if response.usage:
+            usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+
+        return LLMResponse(
+            content=content,
+            model=response.model,
+            usage=usage,
+            raw_response=response.model_dump() if hasattr(response, "model_dump") else None,
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """Simple generation interface.
+
+        Args:
+            prompt: User prompt.
+            system_prompt: Optional system prompt.
+            max_tokens: Override default max tokens.
+            temperature: Override default temperature.
+
+        Returns:
+            Generated text content.
+        """
+        messages = []
+        if system_prompt:
+            messages.append(Message(role="system", content=system_prompt))
+        messages.append(Message(role="user", content=prompt))
+
+        response = self.chat(messages, max_tokens=max_tokens, temperature=temperature)
+        return response.content

--- a/generation/rag_chain.py
+++ b/generation/rag_chain.py
@@ -9,7 +9,7 @@ from typing import Optional
 import chromadb
 from chromadb.utils import embedding_functions
 
-from generation.api_client import LLMClient, LLMConfig
+from .base import BaseLLMClient
 from indexing.embeddings import get_model_path
 
 
@@ -63,13 +63,14 @@ class RAGChain:
 
     def __init__(
         self,
-        llm_client: LLMClient,
+        llm_client: BaseLLMClient,
         config: Optional[RAGConfig] = None,
     ):
         """Initialize the RAG chain.
 
         Args:
-            llm_client: LLM client for generation.
+            llm_client: LLM client for generation. Can be any client
+                       implementing the BaseLLMClient protocol.
             config: RAG configuration.
         """
         self.llm_client = llm_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ tiktoken>=0.5.0
 requests>=2.31.0
 python-dotenv>=1.0.0
 
+# LLM Providers (optional - install based on your provider choice)
+openai>=1.0.0
+anthropic>=0.18.0
+httpx>=0.27.0
+
 # Testing
 pytest>=7.4.0
 pytest-cov>=4.1.0


### PR DESCRIPTION
## Summary
- Implements Strategy Pattern with factory for multiple LLM providers
- Adds support for OpenAI, Anthropic, and Ollama while keeping existing HMAC client intact
- Zero changes to existing `api_client.py` - fully backwards compatible

## Changes
- Add `BaseLLMClient` Protocol interface for structural subtyping
- Add `create_llm_client()` factory function with provider routing
- Add OpenAI, Anthropic, and Ollama provider clients
- Update `RAGChain` to accept any `BaseLLMClient` implementation
- Update `rag_chat.py` CLI with `--provider` flag
- Update `.env.example` with all provider configurations

## Architecture
```
LLM_PROVIDER env var → Factory → BaseLLMClient Protocol
                                        ↑
    ┌───────────┬───────────┬───────────┼───────────┐
    │           │           │           │           │
  Custom    OpenAI    Anthropic     Ollama      (future)
  (HMAC)                            (local)
```

## Test plan
- [ ] Verify default `LLM_PROVIDER=custom` works (backwards compatible)
- [ ] Test with `LLM_PROVIDER=openai` and valid API key
- [ ] Test with `LLM_PROVIDER=anthropic` and valid API key
- [ ] Test with `LLM_PROVIDER=ollama` and local Ollama server
- [ ] Verify `--provider` CLI flag works

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)