### PR TITLE
feat: Create BaseLLMClient protocol interface

### DIFF
--- a/generation/__init__.py
+++ b/generation/__init__.py
@@ -18,9 +18,9 @@ Usage:
     client = create_llm_client("openai")
 """
 
-from .api_client import LLMClient, LLMClientError, LLMConfig, LLMResponse, Message
-from .base import BaseLLMClient
-from .factory import ProviderError, create_llm_client, get_available_providers
+from .api_client import LLMClient, LLMClientError, LLMConfig
+from .base import BaseLLMClient, LLMResponse, Message
+from .factory import ProviderError, create_llm_client, get_available_providers, get_provider_info
 from .rag_chain import RAGChain, RAGConfig, RAGResponse
 
 __all__ = [
@@ -35,6 +35,7 @@ __all__ = [
     # Factory
     "create_llm_client",
     "get_available_providers",
+    "get_provider_info",
     "ProviderError",
     # RAG
     "RAGChain",

--- a/generation/api_client.py
+++ b/generation/api_client.py
@@ -9,10 +9,12 @@ import json
 import os
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 import requests
+
+from .base import LLMResponse, Message
 
 
 @dataclass
@@ -44,24 +46,6 @@ class LLMConfig:
             raise ValueError("BASE_URL environment variable is required")
 
         return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
-
-
-@dataclass
-class Message:
-    """A chat message."""
-
-    role: str
-    content: str
-
-
-@dataclass
-class LLMResponse:
-    """Response from the LLM API."""
-
-    content: str
-    model: Optional[str] = None
-    usage: Optional[dict] = None
-    raw_response: Optional[dict] = field(default=None, repr=False)
 
 
 class LLMClientError(Exception):

--- a/generation/base.py
+++ b/generation/base.py
@@ -7,9 +7,26 @@ compatible without explicit inheritance.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Optional, Protocol, runtime_checkable
 
-from .api_client import LLMResponse, Message
+
+@dataclass
+class Message:
+    """A chat message."""
+
+    role: str
+    content: str
+
+
+@dataclass
+class LLMResponse:
+    """Response from any LLM provider."""
+
+    content: str
+    model: Optional[str] = None
+    usage: Optional[dict] = None
+    raw_response: Optional[dict] = field(default=None, repr=False)
 
 
 @runtime_checkable

--- a/generation/providers/anthropic_client.py
+++ b/generation/providers/anthropic_client.py
@@ -6,7 +6,8 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from ..api_client import LLMClientError, LLMResponse, Message
+from ..api_client import LLMClientError
+from ..base import LLMResponse, Message
 
 
 @dataclass

--- a/generation/providers/ollama_client.py
+++ b/generation/providers/ollama_client.py
@@ -9,7 +9,8 @@ from typing import Optional
 
 import requests
 
-from ..api_client import LLMClientError, LLMResponse, Message
+from ..api_client import LLMClientError
+from ..base import LLMResponse, Message
 
 
 @dataclass

--- a/generation/providers/openai_client.py
+++ b/generation/providers/openai_client.py
@@ -6,7 +6,8 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from ..api_client import LLMClientError, LLMResponse, Message
+from ..api_client import LLMClientError
+from ..base import LLMResponse, Message
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Move `Message` and `LLMResponse` dataclasses from `api_client.py` to `base.py`
- Establish `base.py` as the canonical location for shared protocol types
- Update all provider implementations to import from `base.py`

## Test plan
- [x] Verified `LLMClient` satisfies `BaseLLMClient` protocol
- [x] Verified all provider clients (OpenAI, Anthropic, Ollama) satisfy the protocol
- [x] Ran test suite (227 passed, 1 pre-existing failure unrelated to this change)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)