### PR TITLE
feat: Add Excel file support (.xlsx, .xls)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 ﻿PyPDF2>=3.0.0
 python-docx>=1.1.0
+openpyxl>=3.1.0
+xlrd>=2.0.0
 chromadb>=0.4.22
 sentence-transformers>=2.2.2
 PyYAML>=6.0


### PR DESCRIPTION
## Summary
- Add `load_excel()` handler function to support ingesting Excel spreadsheets into the RAG pipeline
- Multi-sheet workbooks use `[SHEET:name]` markers similar to `[PAGE:N]` for PDFs
- Rows are converted to pipe-separated text for consistent table representation

## Changes
- Add `openpyxl>=3.1.0` and `xlrd>=2.0.0` dependencies to requirements.txt
- Implement `load_excel()` with support for:
  - `.xlsx` files via openpyxl (read-only mode for performance)
  - `.xls` legacy files via xlrd
- Extract metadata: `sheet_names`, `sheet_count`, `total_rows`, `total_columns`, `author`, `creation_date`, `modification_date`
- Handle password-protected and corrupted files gracefully
- Register `.xlsx` and `.xls` handlers in `HANDLERS` dict

## Test plan
- [x] Verified `load_excel()` correctly parses test Excel file with multiple sheets
- [x] Verified metadata extraction works (sheet names, counts, author, dates)
- [x] Verified 227 existing tests still pass (1 pre-existing unrelated failure)
- [ ] Test with password-protected Excel file
- [ ] Test with corrupted Excel file
- [ ] Test with legacy .xls file

Closes #62, closes #63, closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)