### PR TITLE
chore: Remove unused datetime import in models.py

### DIFF
--- a/ingestion/models.py
+++ b/ingestion/models.py
@@ -1,7 +1,6 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from dataclasses import dataclass, field, asdict
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
## Summary
- Removed unused `datetime` import from `ingestion/models.py`
- The `timestamp` field in `FailureInfo` is typed as `str`, not `datetime`, so the import was never used

Closes #44

## Test plan
- [x] Verified module imports successfully with `python -c "from ingestion.models import Document, DocumentChunk, FailureInfo"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)