### PR TITLE
chore: Add openpyxl and xlrd dependencies for Excel support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-﻿PyPDF2>=3.0.0
+PyPDF2>=3.0.0
 python-docx>=1.1.0
+openpyxl>=3.1.0
+xlrd>=2.0.0
 chromadb>=0.4.22
 sentence-transformers>=2.2.2
 PyYAML>=6.0


### PR DESCRIPTION
## Summary
- Added `openpyxl>=3.1.0` for reading/writing Excel 2010+ files (.xlsx)
- Added `xlrd>=2.0.0` for reading legacy Excel 97-2003 files (.xls)

Part of #62 - Add Excel file support

Closes #63

## Test plan
- [x] `pip install -r requirements.txt` succeeds
- [x] Both libraries can be imported successfully:
  - `openpyxl: 3.1.5`
  - `xlrd: 2.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)