### PR TITLE
feat(ingestion): add spreadsheet-to-text flattening for report-like sheets (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,74 @@ config = SpreadsheetClassificationConfig(
 )
 ```
 
+### Spreadsheet Flattening (Report-like)
+
+When a spreadsheet is classified as `report_like`, it can be automatically converted to human-readable text format for better semantic chunking and retrieval:
+
+**Layout Detection:**
+The flattener detects three layout types:
+- **table**: Regular grid with consistent columns, rendered as Markdown tables
+- **form**: Sparse key-value pairs, rendered as prose
+- **mixed**: Combination, uses heuristics to choose best format
+
+**Flattening Strategies:**
+
+*Markdown (for table layouts):*
+```markdown
+## Sheet: Financial Summary
+
+| Category | Q1 | Q2 | Q3 |
+|----------|----|----|-----|
+| Revenue  | 100| 120| 140 |
+```
+
+*Prose (for form/sparse layouts):*
+```
+Sheet: Executive Summary
+
+Title: Q4 2024 Report
+Author: Finance Team
+
+Key Metrics:
+- Total Revenue: $1.2M
+- Growth Rate: 15%
+```
+
+**Special Case Handling:**
+- **Footer notes**: Detected and extracted to separate notes section
+- **Header rows**: Automatically detected for proper table formatting
+- **Empty cells**: Skipped in prose, shown as empty in Markdown tables
+- **Large tables**: Truncated to configurable max rows (default: 100)
+
+**Flattening Metadata:**
+When flattening is applied, the following metadata is added:
+- `flattening_applied`: Boolean indicating if flattening occurred
+- `flattening_strategy`: Either "markdown" or "prose"
+- `layout_type`: Detected layout ("table", "form", or "mixed")
+- `original_row_count`: Total rows before flattening
+- `original_col_count`: Total columns before flattening
+- `sheets_flattened`: Per-sheet details (name, layout, strategy, row/col counts)
+
+**Configuration:**
+Flattening is enabled by default when classification is enabled. It can be configured programmatically:
+```python
+from ingestion import SpreadsheetFlatteningConfig, PipelineConfig
+
+config = PipelineConfig(
+    input_dir=Path("data/raw"),
+    output_dir=Path("data/processed"),
+    spreadsheet_classification_config=SpreadsheetClassificationConfig(),
+    flatten_report_like_spreadsheets=True,  # default: True
+    spreadsheet_flattening_config=SpreadsheetFlatteningConfig(
+        empty_ratio_threshold_form=0.6,
+        max_columns_for_form=4,
+        min_rows_for_table=3,
+        include_sheet_headers=True,
+        max_table_rows_markdown=100,
+    ),
+)
+```
+
 ### Text Normalization
 
 The ingestion pipeline includes configurable text normalization applied after document parsing:

--- a/ingestion/__init__.py
+++ b/ingestion/__init__.py
@@ -8,6 +8,7 @@ from .spreadsheet_classifier import (
     classify_dataframe,
     classify_spreadsheet_file,
 )
+from .spreadsheet_flattener import SpreadsheetFlattener, SpreadsheetFlatteningConfig
 
 __all__ = [
     "ClassificationResult",
@@ -16,6 +17,8 @@ __all__ = [
     "NormalizationResult",
     "PipelineConfig",
     "SpreadsheetClassificationConfig",
+    "SpreadsheetFlattener",
+    "SpreadsheetFlatteningConfig",
     "TextNormalizer",
     "classify_dataframe",
     "classify_spreadsheet_file",

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -18,6 +18,7 @@ from .spreadsheet_classifier import (
     SpreadsheetClassificationConfig,
     classify_dataframe,
 )
+from .spreadsheet_flattener import SpreadsheetFlattener, SpreadsheetFlatteningConfig
 from .storage import StorageManager
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,8 @@ class PipelineConfig:
     enable_sql_tabular: bool = False
     sql_db_path: Optional[Path] = None
     tabular_confidence_threshold: float = 0.7
+    spreadsheet_flattening_config: Optional[SpreadsheetFlatteningConfig] = field(default=None)
+    flatten_report_like_spreadsheets: bool = True
 
 
 @dataclass
@@ -260,6 +263,25 @@ class IngestionPipeline:
                         document.doc_id,
                         classification.classification,
                         classification.confidence * 100,
+                    )
+
+                # Flatten report-like spreadsheets for better chunking
+                if (
+                    classification
+                    and classification.classification == "report_like"
+                    and self.config.flatten_report_like_spreadsheets
+                ):
+                    flattener = SpreadsheetFlattener(self.config.spreadsheet_flattening_config)
+                    document.text, flatten_meta = flattener.flatten(
+                        document.text,
+                        document.metadata,
+                    )
+                    document.metadata.update(flatten_meta)
+                    logger.info(
+                        "Flattened %s using %s strategy (layout: %s)",
+                        document.doc_id,
+                        flatten_meta.get("flattening_strategy", "unknown"),
+                        flatten_meta.get("layout_type", "unknown"),
                     )
 
                 # Route to SQL path for tabular spreadsheets

--- a/ingestion/spreadsheet_flattener.py
+++ b/ingestion/spreadsheet_flattener.py
@@ -1,0 +1,485 @@
+"""Spreadsheet-to-text flattening for report-like sheets.
+
+This module converts report-like spreadsheets (classified by spreadsheet_classifier)
+into human-readable text formats (Markdown tables or prose) for better semantic
+chunking and retrieval.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SpreadsheetFlatteningConfig:
+    """Configuration for spreadsheet flattening behavior.
+
+    Attributes:
+        empty_ratio_threshold_form: Empty cell ratio above which layout is "form".
+        max_columns_for_form: Maximum columns to consider a layout as "form".
+        min_rows_for_table: Minimum rows to consider a layout as "table".
+        include_sheet_headers: Whether to include sheet name as section header.
+        max_table_rows_markdown: Maximum rows before switching to prose for tables.
+        notes_patterns: Regex patterns to detect footer notes in cells.
+    """
+
+    empty_ratio_threshold_form: float = 0.6
+    max_columns_for_form: int = 4
+    min_rows_for_table: int = 3
+    include_sheet_headers: bool = True
+    max_table_rows_markdown: int = 100
+    notes_patterns: List[str] = field(
+        default_factory=lambda: [
+            r"^note[s]?:",
+            r"^see ",
+            r"^\*",
+            r"^source:",
+        ]
+    )
+
+
+LayoutType = Literal["table", "form", "mixed"]
+
+
+def _compute_empty_ratio(df: pd.DataFrame) -> float:
+    """Compute the ratio of empty/null cells in a DataFrame.
+
+    Args:
+        df: Input DataFrame.
+
+    Returns:
+        Ratio of empty cells (0.0 to 1.0).
+    """
+    if df.empty:
+        return 1.0
+
+    total_cells = df.size
+    if total_cells == 0:
+        return 1.0
+
+    na_count = df.isna().sum().sum()
+    empty_string_count = 0
+
+    for col in df.columns:
+        non_na_mask = df[col].notna()
+        if non_na_mask.any():
+            str_values = df.loc[non_na_mask, col].astype(str)
+            empty_string_count += (str_values.str.strip() == "").sum()
+
+    return (na_count + empty_string_count) / total_cells
+
+
+def _has_header_row(df: pd.DataFrame) -> bool:
+    """Detect if the first row looks like a header.
+
+    Heuristics:
+    - First row is all strings
+    - First row values are distinct
+    - Data rows have different types than header
+
+    Args:
+        df: Input DataFrame.
+
+    Returns:
+        True if first row appears to be a header.
+    """
+    if df.empty or len(df) < 2:
+        return False
+
+    first_row = df.iloc[0]
+
+    # Check if first row is all non-numeric strings
+    all_strings = True
+    for val in first_row:
+        if pd.isna(val):
+            continue
+        try:
+            float(val)
+            all_strings = False
+            break
+        except (ValueError, TypeError):
+            pass
+
+    if not all_strings:
+        return False
+
+    # Check if values are unique (typical for headers)
+    non_empty_values = [str(v).strip() for v in first_row if pd.notna(v) and str(v).strip()]
+    return len(non_empty_values) == len(set(non_empty_values))
+
+
+def _extract_notes(df: pd.DataFrame, patterns: List[str]) -> Tuple[pd.DataFrame, List[str]]:
+    """Extract footer notes from the DataFrame.
+
+    Scans the last rows for cells matching note patterns and removes them.
+
+    Args:
+        df: Input DataFrame.
+        patterns: List of regex patterns to match notes.
+
+    Returns:
+        Tuple of (DataFrame without notes, list of extracted notes).
+    """
+    notes = []
+    rows_to_drop = []
+
+    compiled_patterns = [re.compile(p, re.IGNORECASE) for p in patterns]
+
+    # Scan last 10 rows for notes
+    scan_rows = min(10, len(df))
+    for idx in range(len(df) - scan_rows, len(df)):
+        row = df.iloc[idx]
+        row_is_note = False
+
+        for val in row:
+            if pd.isna(val):
+                continue
+            val_str = str(val).strip()
+            if not val_str:
+                continue
+
+            for pattern in compiled_patterns:
+                if pattern.match(val_str):
+                    notes.append(val_str)
+                    row_is_note = True
+                    break
+            if row_is_note:
+                break
+
+        if row_is_note:
+            rows_to_drop.append(idx)
+
+    if rows_to_drop:
+        df = df.drop(df.index[rows_to_drop])
+
+    return df, notes
+
+
+class SpreadsheetFlattener:
+    """Convert report-like spreadsheets to readable text."""
+
+    def __init__(self, config: Optional[SpreadsheetFlatteningConfig] = None):
+        """Initialize the flattener.
+
+        Args:
+            config: Flattening configuration. Uses defaults if None.
+        """
+        self.config = config or SpreadsheetFlatteningConfig()
+
+    def detect_layout_type(self, df: pd.DataFrame) -> LayoutType:
+        """Detect the layout type of a DataFrame.
+
+        Args:
+            df: Input DataFrame.
+
+        Returns:
+            Layout type: "table", "form", or "mixed".
+        """
+        if df.empty:
+            return "form"
+
+        empty_ratio = _compute_empty_ratio(df)
+        col_count = len(df.columns)
+        row_count = len(df)
+
+        # Form layout: sparse data, few columns, key-value pairs
+        if (
+            empty_ratio >= self.config.empty_ratio_threshold_form
+            and col_count <= self.config.max_columns_for_form
+        ):
+            return "form"
+
+        # Table layout: regular grid with consistent columns
+        if row_count >= self.config.min_rows_for_table and empty_ratio < 0.3:
+            return "table"
+
+        # Mixed: moderate sparsity or doesn't fit either pattern
+        return "mixed"
+
+    def flatten_to_markdown(
+        self,
+        df: pd.DataFrame,
+        sheet_name: str,
+        notes: Optional[List[str]] = None,
+    ) -> str:
+        """Convert a DataFrame to Markdown table format.
+
+        Args:
+            df: Input DataFrame.
+            sheet_name: Name of the sheet for the header.
+            notes: Optional list of notes to append.
+
+        Returns:
+            Markdown-formatted string with table.
+        """
+        parts = []
+
+        if self.config.include_sheet_headers:
+            parts.append(f"## Sheet: {sheet_name}")
+            parts.append("")
+
+        if df.empty:
+            parts.append("*Empty sheet*")
+            return "\n".join(parts)
+
+        # Determine if first row is header
+        has_header = _has_header_row(df)
+
+        if has_header:
+            headers = [str(v).strip() if pd.notna(v) else "" for v in df.iloc[0]]
+            data_df = df.iloc[1:]
+        else:
+            headers = [f"Col{i+1}" for i in range(len(df.columns))]
+            data_df = df
+
+        # Build markdown table
+        # Header row
+        header_line = "| " + " | ".join(headers) + " |"
+        separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+        parts.append(header_line)
+        parts.append(separator)
+
+        # Data rows (limit to max_table_rows_markdown)
+        rows_to_render = min(len(data_df), self.config.max_table_rows_markdown)
+        for idx in range(rows_to_render):
+            row = data_df.iloc[idx]
+            cells = [str(v).strip() if pd.notna(v) else "" for v in row]
+            # Escape pipe characters in cell content
+            cells = [c.replace("|", "\\|") for c in cells]
+            row_line = "| " + " | ".join(cells) + " |"
+            parts.append(row_line)
+
+        if len(data_df) > self.config.max_table_rows_markdown:
+            parts.append("")
+            parts.append(f"*... and {len(data_df) - self.config.max_table_rows_markdown} more rows*")
+
+        # Append notes if present
+        if notes:
+            parts.append("")
+            parts.append("**Notes:**")
+            for note in notes:
+                parts.append(f"- {note}")
+
+        return "\n".join(parts)
+
+    def flatten_to_prose(
+        self,
+        df: pd.DataFrame,
+        sheet_name: str,
+        notes: Optional[List[str]] = None,
+    ) -> str:
+        """Convert a DataFrame to prose format for sparse/form layouts.
+
+        Args:
+            df: Input DataFrame.
+            sheet_name: Name of the sheet for the header.
+            notes: Optional list of notes to append.
+
+        Returns:
+            Prose-formatted string.
+        """
+        parts = []
+
+        if self.config.include_sheet_headers:
+            parts.append(f"Sheet: {sheet_name}")
+            parts.append("")
+
+        if df.empty:
+            parts.append("(Empty sheet)")
+            return "\n".join(parts)
+
+        # For form layout, try to detect key-value pairs
+        col_count = len(df.columns)
+
+        if col_count == 2:
+            # Likely key-value pairs
+            for _, row in df.iterrows():
+                key = str(row.iloc[0]).strip() if pd.notna(row.iloc[0]) else ""
+                value = str(row.iloc[1]).strip() if pd.notna(row.iloc[1]) else ""
+                if key or value:
+                    if key and value:
+                        parts.append(f"{key}: {value}")
+                    elif key:
+                        parts.append(f"{key}")
+                    else:
+                        parts.append(f"  {value}")
+        else:
+            # Mixed/irregular layout - list all non-empty cells
+            current_section = None
+
+            for _, row in df.iterrows():
+                non_empty_cells = []
+                for val in row:
+                    if pd.notna(val):
+                        val_str = str(val).strip()
+                        if val_str:
+                            non_empty_cells.append(val_str)
+
+                if not non_empty_cells:
+                    continue
+
+                # If single cell, might be a section header
+                if len(non_empty_cells) == 1:
+                    cell = non_empty_cells[0]
+                    # Check if it looks like a header (short, no punctuation at end)
+                    if len(cell) < 50 and not cell.endswith((".", ":", ",")):
+                        if current_section:
+                            parts.append("")
+                        current_section = cell
+                        parts.append(f"{cell}:")
+                        continue
+
+                # Multiple values - format as list or comma-separated
+                if len(non_empty_cells) <= 3:
+                    parts.append("- " + ", ".join(non_empty_cells))
+                else:
+                    # First cell might be a label
+                    label = non_empty_cells[0]
+                    values = non_empty_cells[1:]
+                    parts.append(f"- {label}: {', '.join(values)}")
+
+        # Append notes if present
+        if notes:
+            parts.append("")
+            parts.append("Notes:")
+            for note in notes:
+                parts.append(f"- {note}")
+
+        return "\n".join(parts)
+
+    def _parse_sheet_text(self, text: str) -> List[Tuple[str, pd.DataFrame]]:
+        """Parse pipe-separated text with [SHEET:name] markers into DataFrames.
+
+        Args:
+            text: Text with sheet markers and pipe-separated rows.
+
+        Returns:
+            List of (sheet_name, DataFrame) tuples.
+        """
+        sheets = []
+        sheet_pattern = re.compile(r"\[SHEET:([^\]]+)\]")
+
+        # Split by sheet markers
+        parts = sheet_pattern.split(text)
+
+        # parts[0] is content before first marker (usually empty)
+        # parts[1] is first sheet name, parts[2] is its content, etc.
+        for i in range(1, len(parts), 2):
+            if i + 1 < len(parts):
+                sheet_name = parts[i].strip()
+                sheet_content = parts[i + 1].strip()
+
+                if not sheet_content:
+                    sheets.append((sheet_name, pd.DataFrame()))
+                    continue
+
+                # Parse pipe-separated rows
+                rows = []
+                for line in sheet_content.split("\n"):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    cells = [cell.strip() for cell in line.split("|")]
+                    rows.append(cells)
+
+                if rows:
+                    # Normalize row lengths
+                    max_cols = max(len(row) for row in rows)
+                    normalized_rows = [
+                        row + [""] * (max_cols - len(row)) for row in rows
+                    ]
+                    df = pd.DataFrame(normalized_rows)
+                else:
+                    df = pd.DataFrame()
+
+                sheets.append((sheet_name, df))
+
+        return sheets
+
+    def flatten(
+        self,
+        text: str,
+        metadata: Dict[str, Any],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Flatten spreadsheet text to human-readable format.
+
+        Main entry point for flattening. Parses the pipe-separated text,
+        detects layout type, and applies appropriate flattening strategy.
+
+        Args:
+            text: Document text with [SHEET:name] markers and pipe-separated rows.
+            metadata: Document metadata dict.
+
+        Returns:
+            Tuple of (flattened_text, flattening_metadata).
+        """
+        flatten_meta: Dict[str, Any] = {
+            "flattening_applied": True,
+            "sheets_flattened": [],
+        }
+
+        sheets = self._parse_sheet_text(text)
+
+        if not sheets:
+            logger.warning("No sheets found in text, returning original")
+            flatten_meta["flattening_applied"] = False
+            return text, flatten_meta
+
+        flattened_parts = []
+        total_rows = 0
+        total_cols = 0
+
+        for sheet_name, df in sheets:
+            # Extract notes before processing
+            df_clean, notes = _extract_notes(df, self.config.notes_patterns)
+
+            # Detect layout type
+            layout_type = self.detect_layout_type(df_clean)
+
+            # Track stats
+            total_rows += len(df)
+            total_cols = max(total_cols, len(df.columns) if not df.empty else 0)
+
+            # Apply appropriate flattening strategy
+            if layout_type == "table":
+                flattened = self.flatten_to_markdown(df_clean, sheet_name, notes)
+                strategy = "markdown"
+            else:
+                flattened = self.flatten_to_prose(df_clean, sheet_name, notes)
+                strategy = "prose"
+
+            flattened_parts.append(flattened)
+
+            flatten_meta["sheets_flattened"].append({
+                "sheet_name": sheet_name,
+                "layout_type": layout_type,
+                "flattening_strategy": strategy,
+                "row_count": len(df),
+                "col_count": len(df.columns) if not df.empty else 0,
+                "notes_extracted": len(notes),
+            })
+
+            logger.debug(
+                "Flattened sheet '%s' using %s strategy (layout: %s)",
+                sheet_name,
+                strategy,
+                layout_type,
+            )
+
+        # Use the dominant strategy for the overall metadata
+        strategies = [s["flattening_strategy"] for s in flatten_meta["sheets_flattened"]]
+        flatten_meta["flattening_strategy"] = max(set(strategies), key=strategies.count) if strategies else "prose"
+
+        layouts = [s["layout_type"] for s in flatten_meta["sheets_flattened"]]
+        flatten_meta["layout_type"] = max(set(layouts), key=layouts.count) if layouts else "mixed"
+
+        flatten_meta["original_row_count"] = total_rows
+        flatten_meta["original_col_count"] = total_cols
+
+        return "\n\n".join(flattened_parts), flatten_meta

--- a/tests/test_spreadsheet_flattener.py
+++ b/tests/test_spreadsheet_flattener.py
@@ -1,0 +1,382 @@
+"""Unit tests for spreadsheet flattener (report-like to text conversion)."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ingestion.spreadsheet_flattener import (
+    SpreadsheetFlattener,
+    SpreadsheetFlatteningConfig,
+    _compute_empty_ratio,
+    _has_header_row,
+    _extract_notes,
+)
+
+
+class TestComputeEmptyRatio:
+    """Tests for empty ratio computation."""
+
+    def test_empty_ratio_no_empty(self):
+        """Test empty ratio with no empty cells."""
+        df = pd.DataFrame({
+            "col1": [1, 2, 3],
+            "col2": ["a", "b", "c"],
+        })
+        ratio = _compute_empty_ratio(df)
+        assert ratio == 0.0
+
+    def test_empty_ratio_all_empty(self):
+        """Test empty ratio with all empty cells."""
+        df = pd.DataFrame({
+            "col1": [None, None],
+            "col2": ["", ""],
+        })
+        ratio = _compute_empty_ratio(df)
+        assert ratio == 1.0
+
+    def test_empty_ratio_mixed(self):
+        """Test empty ratio with mixed content."""
+        df = pd.DataFrame({
+            "col1": [1, None],
+            "col2": ["a", ""],
+        })
+        ratio = _compute_empty_ratio(df)
+        assert ratio == 0.5
+
+    def test_empty_ratio_empty_df(self):
+        """Test empty ratio with empty DataFrame."""
+        df = pd.DataFrame()
+        ratio = _compute_empty_ratio(df)
+        assert ratio == 1.0
+
+
+class TestHasHeaderRow:
+    """Tests for header row detection."""
+
+    def test_header_row_with_string_header(self):
+        """Test detection of string header row."""
+        df = pd.DataFrame({
+            0: ["Name", "Alice", "Bob"],
+            1: ["Age", "25", "30"],
+        })
+        assert _has_header_row(df) is True
+
+    def test_header_row_with_numeric_first_row(self):
+        """Test that numeric first row is not detected as header."""
+        df = pd.DataFrame({
+            0: [1, 2, 3],
+            1: [4, 5, 6],
+        })
+        assert _has_header_row(df) is False
+
+    def test_header_row_empty_df(self):
+        """Test header detection with empty DataFrame."""
+        df = pd.DataFrame()
+        assert _has_header_row(df) is False
+
+    def test_header_row_single_row(self):
+        """Test header detection with single row."""
+        df = pd.DataFrame({0: ["Name"], 1: ["Age"]})
+        assert _has_header_row(df) is False
+
+
+class TestExtractNotes:
+    """Tests for footer note extraction."""
+
+    def test_extract_notes_with_note_pattern(self):
+        """Test extraction of notes matching patterns."""
+        df = pd.DataFrame({
+            0: ["Data", "More data", "Note: See appendix"],
+            1: ["Value", "Value 2", ""],
+        })
+        df_clean, notes = _extract_notes(df, [r"^note[s]?:"])
+        assert len(notes) == 1
+        assert "See appendix" in notes[0]
+        assert len(df_clean) == 2
+
+    def test_extract_notes_no_notes(self):
+        """Test extraction when no notes present."""
+        df = pd.DataFrame({
+            0: ["Data", "More data"],
+            1: ["Value", "Value 2"],
+        })
+        df_clean, notes = _extract_notes(df, [r"^note[s]?:"])
+        assert len(notes) == 0
+        assert len(df_clean) == 2
+
+    def test_extract_notes_multiple_patterns(self):
+        """Test extraction with multiple patterns."""
+        df = pd.DataFrame({
+            0: ["Data", "Source: Company report", "*Important disclaimer"],
+        })
+        df_clean, notes = _extract_notes(df, [r"^source:", r"^\*"])
+        assert len(notes) == 2
+
+
+class TestSpreadsheetFlattenerLayoutDetection:
+    """Tests for layout type detection."""
+
+    def test_detect_table_layout(self):
+        """Test detection of table layout."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({
+            "col1": range(10),
+            "col2": range(10),
+            "col3": range(10),
+        })
+        layout = flattener.detect_layout_type(df)
+        assert layout == "table"
+
+    def test_detect_form_layout(self):
+        """Test detection of form layout (sparse, few columns)."""
+        config = SpreadsheetFlatteningConfig(
+            empty_ratio_threshold_form=0.5,
+            max_columns_for_form=4,
+        )
+        flattener = SpreadsheetFlattener(config)
+        df = pd.DataFrame({
+            "key": ["Name", "Date", None],
+            "value": ["Report", None, None],
+        })
+        layout = flattener.detect_layout_type(df)
+        assert layout == "form"
+
+    def test_detect_mixed_layout(self):
+        """Test detection of mixed layout."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({
+            "col1": [1, None, 3, None, 5],
+            "col2": ["a", None, "c", None, "e"],
+            "col3": [None, "x", None, "y", None],
+        })
+        layout = flattener.detect_layout_type(df)
+        assert layout == "mixed"
+
+    def test_detect_empty_layout(self):
+        """Test layout detection with empty DataFrame."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame()
+        layout = flattener.detect_layout_type(df)
+        assert layout == "form"
+
+
+class TestFlattenToMarkdown:
+    """Tests for Markdown table flattening."""
+
+    def test_flatten_simple_table(self):
+        """Test flattening of simple table to Markdown."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({
+            0: ["Name", "Alice", "Bob"],
+            1: ["Age", "25", "30"],
+        })
+        result = flattener.flatten_to_markdown(df, "Test Sheet")
+
+        assert "## Sheet: Test Sheet" in result
+        assert "| Name | Age |" in result
+        assert "| Alice | 25 |" in result
+        assert "| Bob | 30 |" in result
+        assert "---" in result  # Separator line
+
+    def test_flatten_with_notes(self):
+        """Test flattening with appended notes."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({0: ["Header", "Data"]})
+        notes = ["See appendix A", "Data as of 2024"]
+        result = flattener.flatten_to_markdown(df, "Sheet", notes)
+
+        assert "**Notes:**" in result
+        assert "- See appendix A" in result
+        assert "- Data as of 2024" in result
+
+    def test_flatten_empty_sheet(self):
+        """Test flattening empty sheet."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame()
+        result = flattener.flatten_to_markdown(df, "Empty")
+
+        assert "## Sheet: Empty" in result
+        assert "*Empty sheet*" in result
+
+    def test_flatten_escapes_pipes(self):
+        """Test that pipe characters in cells are escaped."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({
+            0: ["Header", "Value|With|Pipes"],
+        })
+        result = flattener.flatten_to_markdown(df, "Sheet")
+
+        assert r"Value\|With\|Pipes" in result
+
+    def test_flatten_respects_max_rows(self):
+        """Test that large tables are truncated."""
+        config = SpreadsheetFlatteningConfig(max_table_rows_markdown=5)
+        flattener = SpreadsheetFlattener(config)
+        df = pd.DataFrame({0: ["Header"] + [f"Row{i}" for i in range(20)]})
+        result = flattener.flatten_to_markdown(df, "Sheet")
+
+        assert "... and 15 more rows" in result
+
+
+class TestFlattenToProse:
+    """Tests for prose flattening."""
+
+    def test_flatten_key_value_pairs(self):
+        """Test flattening of key-value pairs."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({
+            0: ["Name", "Date", "Author"],
+            1: ["Q4 Report", "2024-01-15", "Finance Team"],
+        })
+        result = flattener.flatten_to_prose(df, "Summary")
+
+        assert "Sheet: Summary" in result
+        assert "Name: Q4 Report" in result
+        assert "Date: 2024-01-15" in result
+        assert "Author: Finance Team" in result
+
+    def test_flatten_empty_sheet_prose(self):
+        """Test prose flattening of empty sheet."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame()
+        result = flattener.flatten_to_prose(df, "Empty")
+
+        assert "Sheet: Empty" in result
+        assert "(Empty sheet)" in result
+
+    def test_flatten_with_notes_prose(self):
+        """Test prose flattening with notes."""
+        flattener = SpreadsheetFlattener()
+        df = pd.DataFrame({0: ["Key"], 1: ["Value"]})
+        notes = ["Important note"]
+        result = flattener.flatten_to_prose(df, "Sheet", notes)
+
+        assert "Notes:" in result
+        assert "- Important note" in result
+
+
+class TestFlattenMain:
+    """Tests for main flatten() method."""
+
+    def test_flatten_single_sheet(self):
+        """Test flattening single sheet text."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Sales]\nProduct | Price | Qty\nApple | 1.50 | 100\nBanana | 0.75 | 200"
+        metadata = {}
+
+        result_text, result_meta = flattener.flatten(text, metadata)
+
+        assert result_meta["flattening_applied"] is True
+        assert len(result_meta["sheets_flattened"]) == 1
+        assert result_meta["sheets_flattened"][0]["sheet_name"] == "Sales"
+        assert "original_row_count" in result_meta
+
+    def test_flatten_multiple_sheets(self):
+        """Test flattening multiple sheets."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Sheet1]\na | b\n1 | 2\n\n[SHEET:Sheet2]\nx | y\n3 | 4"
+        metadata = {}
+
+        result_text, result_meta = flattener.flatten(text, metadata)
+
+        assert len(result_meta["sheets_flattened"]) == 2
+        assert "Sheet1" in result_text
+        assert "Sheet2" in result_text
+
+    def test_flatten_no_sheets_found(self):
+        """Test handling of text without sheet markers."""
+        flattener = SpreadsheetFlattener()
+        text = "Just some plain text without any sheet markers"
+        metadata = {}
+
+        result_text, result_meta = flattener.flatten(text, metadata)
+
+        assert result_meta["flattening_applied"] is False
+        assert result_text == text
+
+    def test_flatten_preserves_metadata(self):
+        """Test that flattening adds to existing metadata."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Test]\na | b\n1 | 2"
+        metadata = {"existing_key": "existing_value"}
+
+        _, result_meta = flattener.flatten(text, metadata)
+
+        # Original metadata should be preserved (not modified in place)
+        assert "existing_key" not in result_meta  # We return new metadata
+        assert "flattening_applied" in result_meta
+
+
+class TestSpreadsheetFlatteningConfig:
+    """Tests for SpreadsheetFlatteningConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = SpreadsheetFlatteningConfig()
+
+        assert config.empty_ratio_threshold_form == 0.6
+        assert config.max_columns_for_form == 4
+        assert config.min_rows_for_table == 3
+        assert config.include_sheet_headers is True
+        assert config.max_table_rows_markdown == 100
+        assert len(config.notes_patterns) > 0
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = SpreadsheetFlatteningConfig(
+            empty_ratio_threshold_form=0.8,
+            max_columns_for_form=6,
+            include_sheet_headers=False,
+        )
+
+        assert config.empty_ratio_threshold_form == 0.8
+        assert config.max_columns_for_form == 6
+        assert config.include_sheet_headers is False
+
+
+class TestParseSheetText:
+    """Tests for internal _parse_sheet_text method."""
+
+    def test_parse_single_sheet(self):
+        """Test parsing single sheet."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Data]\na | b | c\n1 | 2 | 3"
+
+        sheets = flattener._parse_sheet_text(text)
+
+        assert len(sheets) == 1
+        assert sheets[0][0] == "Data"
+        assert len(sheets[0][1]) == 2  # 2 rows
+
+    def test_parse_multiple_sheets(self):
+        """Test parsing multiple sheets."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:First]\na | b\n[SHEET:Second]\nx | y | z"
+
+        sheets = flattener._parse_sheet_text(text)
+
+        assert len(sheets) == 2
+        assert sheets[0][0] == "First"
+        assert sheets[1][0] == "Second"
+
+    def test_parse_empty_sheet(self):
+        """Test parsing empty sheet."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Empty]\n[SHEET:HasData]\na | b"
+
+        sheets = flattener._parse_sheet_text(text)
+
+        assert len(sheets) == 2
+        assert sheets[0][0] == "Empty"
+        assert sheets[0][1].empty
+        assert not sheets[1][1].empty
+
+    def test_parse_normalizes_row_lengths(self):
+        """Test that rows are normalized to same length."""
+        flattener = SpreadsheetFlattener()
+        text = "[SHEET:Test]\na | b | c\nx | y"  # Second row has fewer columns
+
+        sheets = flattener._parse_sheet_text(text)
+
+        df = sheets[0][1]
+        assert all(len(row) == 3 for _, row in df.iterrows())


### PR DESCRIPTION
## Summary

- Implements intelligent flattening of report-like spreadsheets into human-readable text formats
- Adds layout detection (table, form, mixed) based on data structure heuristics
- Provides Markdown table flattening for regular grid layouts with automatic header detection
- Provides prose flattening for sparse/form-style key-value data
- Includes automatic footer note extraction with configurable patterns

## Changes

**New files:**
- `ingestion/spreadsheet_flattener.py` - `SpreadsheetFlattener` class with layout detection and flattening methods
- `tests/test_spreadsheet_flattener.py` - 33 unit tests covering all functionality

**Modified files:**
- `ingestion/pipeline.py` - Integration after classification, before chunking
- `ingestion/__init__.py` - Export new classes
- `CLAUDE.md` - Documentation for the new feature

## Test plan

- [x] All 33 new unit tests pass
- [x] All 32 existing spreadsheet classifier tests pass
- [ ] Manual test with sample report-like spreadsheet through full pipeline
- [ ] Verify flattened content is retrievable via Docs Agent

Closes #95

🤖 Generated with [Claude Code](https://claude.ai/code)